### PR TITLE
Fix markdown comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kramit - A Pure Elixir Markdown Superset for HTML5
 
-###Rationale
+### Rationale
+
 Markdown was originally created to ensure *good and semantic markup* on the web during the era the HTML4 era. This has served the internet well and has overall improved the quality and accessibility of the web.
 
 In the HTML5 era, markup has pushed the web to even better semantics and also the bandwidth availability has increased the usage of elements like videos directly in HTML; which was not really addressed by the original Markdown spec.
@@ -28,13 +29,13 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
 ## Features
 
-###Table of Contents
+### Table of Contents
 
 Generate with this tag in your markdown document.
 ```
 #toc
 ```
 
-###Videos
+### Videos
 
 Coming soon

--- a/lib/kramit.ex
+++ b/lib/kramit.ex
@@ -3,14 +3,13 @@ defmodule Kramit do
   # Kramit - A Pure Elixir Markdown Superset for HTML5
 
   ### Rationale
-  Markdown was originally created to ensure *good and smeantic markup* on the web during the era the HTML4 era. This has served the internet well and has overall improved the quailtity and accebiltiy of the web.
+  Markdown was originally created to ensure *good and semantic markup* on the web during the era the HTML4 era. This has served the internet well and has overall improved the quality and accessibility of the web.
 
-  In more recent times the HTML5 markup has pushed the web to even better symatic make up and also the bandwidth concerns of the web has increase the usage of such things as videos directly in Markup which are not really addressed by the Markdown spec.
+  In the HTML5 era, markup has pushed the web to even better semantics and also the bandwidth availability has increased the usage of elements like videos directly in HTML; which was not really addressed by the original Markdown spec.
 
   Taking a queue from Kramdown[http://kramdown.gettalong.org/] we started adding additional syntax to make the web more usable and readable for us.
 
   To that end the core value of Kramit is we want to add to the markdown spec, via Elixir, is to make the web a more beautiful, useable, and modern place.
-
 
   """
   #Public Interface

--- a/lib/kramit.ex
+++ b/lib/kramit.ex
@@ -1,8 +1,8 @@
 defmodule Kramit do
   @moduledoc """
-  #Kramit - A Pure Elixir Markdown Superset for HTML5
+  # Kramit - A Pure Elixir Markdown Superset for HTML5
 
-  ###Rationale
+  ### Rationale
   Markdown was originally created to ensure *good and smeantic markup* on the web during the era the HTML4 era. This has served the internet well and has overall improved the quailtity and accebiltiy of the web.
 
   In more recent times the HTML5 markup has pushed the web to even better symatic make up and also the bandwidth concerns of the web has increase the usage of such things as videos directly in Markup which are not really addressed by the Markdown spec.


### PR DESCRIPTION
Some of the headings aren't being rendered correctly on hexdocs.pm (but are on github). Hopefully this should fix these.

![hexdocs pm error - 1](https://cloud.githubusercontent.com/assets/345553/16379951/325ed48a-3cc8-11e6-87fb-894627d0236d.png)
![hexdocs pm error 1](https://cloud.githubusercontent.com/assets/345553/16379952/33cec5dc-3cc8-11e6-8c72-c6b3ebbe1651.png)
